### PR TITLE
Mobile scaling: header and home page

### DIFF
--- a/src/components/BigPlayerOfTheWeek.js
+++ b/src/components/BigPlayerOfTheWeek.js
@@ -88,10 +88,6 @@ export default function BigPlayerOfTheWeek({ user, avatar }) {
               <StatHeading>weekly wins</StatHeading>
               <Stat>{user?.weeklyWins ?? '-'}</Stat>
             </StatColumn>
-            <StatColumn>
-              <StatHeading>$prem earned</StatHeading>
-              <Stat>{user?.premEarned ?? '-'}</Stat>
-            </StatColumn>
           </StatsRow>
         </Column>
       </PlayerRow>

--- a/src/components/Buttons.js
+++ b/src/components/Buttons.js
@@ -49,6 +49,9 @@ const SignupLarge = styled(Button)`
 const ViewTournaments = styled(Button)`
   width: 252px;
   height: 36px;
+  @media screen and (max-width: 736px) {
+    margin:auto;
+  }
 `
 
 const ArrowButtonContainer = styled(GradientText)`
@@ -82,10 +85,8 @@ export function LoginButton({ text, disabled, ...props }) {
 
 export function ViewTournamentsButton() {
   return (
-    <Link href={'/tournaments'}>
-      <a>
-        <ViewTournaments>view tournaments</ViewTournaments>
-      </a>
+    <Link href={'/tournaments'} >
+      <ViewTournaments>view tournaments</ViewTournaments>   
     </Link>
   )
 }

--- a/src/components/CurrentUserProfileTop.js
+++ b/src/components/CurrentUserProfileTop.js
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import { Column, Container, Row } from 'components/common'
 import { useState } from 'react'
 import Friends from 'components/Friends'
-import Teams from 'components/Teams'
 import Home from 'components/ProfileHome'
 import Link from 'next/link'
 import AuthenticationContext from 'contexts/authentication'
@@ -73,6 +72,7 @@ const Numbers = styled.div`
 const ButtonWrapper = styled(Row)`
   justify-content: space-between;
   margin-top: 79px;
+  width: 800px;
 `
 
 const Button = styled.div`
@@ -126,7 +126,6 @@ export default function ProfileTop() {
             {userAvatar && user && <Avatar src={userAvatar} />}
             <ProfileInfo>
               <Name>{user?.username || user?.email}</Name>
-              <Team>{user?.team ?? 'ASO LTD'}</Team>
               <ProfileStats>
                 <GreyTextColumn>
                   <GreyText>rank</GreyText>
@@ -158,12 +157,6 @@ export default function ProfileTop() {
             event history
           </Button>
           <Button
-            style={{ borderBottom: `${selected == 'Teams' ? 1 : 0}px solid` }}
-            onClick={() => setSelected('Teams')}
-          >
-            teams
-          </Button>
-          <Button
             style={{ borderBottom: `${selected == 'Friends' ? 1 : 0}px solid` }}
             onClick={() => setSelected('Friends')}
           >
@@ -176,7 +169,6 @@ export default function ProfileTop() {
           </Link>
         </ButtonWrapper>
       </Wrapper>
-      {selected == 'Teams' && <Teams />}
       {selected == 'Friends' && (
         <Friends friends={friends} invites={invites} avatars={avatars} />
       )}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -21,12 +21,6 @@ const Header = styled(Row)`
 `
 
 const LogoBit = styled(Row)`
-  min-width: 205px;
-  margin-right: 50px;
-  @media screen and (max-width: 600px) {
-    margin-right: 0px;
-    margin-left: 25px;
-  }
 `
 
 const LinksBit = styled(Row)`
@@ -191,8 +185,8 @@ export default function _Header({ home }) {
         >
           <Image
             src={navigatorOpen ? '/navigator_open.svg' : '/navigator.svg'}
-            width={24}
-            height={24}
+            width={34}
+            height={34}
             alt={'navigator'}
           />
         </LinksDropdown>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -17,10 +17,6 @@ const Header = styled(Row)`
   padding-right: 30px;
   width: min(80%, 1400px);
   margin: auto;
-  @media screen and (max-width: 600px) {
-    width: 480px;
-    padding: 0;
-  }
   margin-bottom: ${(props) => (props.home ? '80px' : '150px')};
 `
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -210,9 +210,9 @@ export default function _Header({ home }) {
         <Navigator
           ref={ref}
           currentUser={user}
-          isAuthenticated={user.isAuthenticated}
+          isAuthenticated={user ? user.isAuthenticated : null}
         />
-      )}
+      ) }
       <LinksBit>
         <Link href={'/games'}>
           <a>

--- a/src/components/HomeHeading.js
+++ b/src/components/HomeHeading.js
@@ -7,18 +7,24 @@ const Heading = styled.div`
   font-family: Inter;
   font-style: italic;
   font-weight: bold;
-  font-size: 78px;
+  font-size: 3rem;
   line-height: 150%;
   letter-spacing: 0.055em;
   color: ${(props) => props.theme.colors.black};
   text-transform: uppercase;
   margin-bottom: 10px;
+  @media screen and (max-width: 736px) {
+    margin:auto;
+  }
 `
 
 const Container = styled(Row)`
   align-items: center;
   justify-content: space-between;
   margin-bottom: 150px;
+  @media screen and (max-width: 736px) {
+    display: block;
+  }
 `
 
 const SideColumn = styled(Column)``
@@ -31,6 +37,9 @@ const Subheading = styled.div`
   line-height: 150%;
   color: ${(props) => props.theme.colors.black};
   margin-bottom: 70px;
+  @media screen and (max-width: 736px) {
+    text-align: center;
+  }
 `
 
 export default function HomeHeading() {

--- a/src/components/LogoHeader.js
+++ b/src/components/LogoHeader.js
@@ -11,6 +11,8 @@ const LogoHeader = styled.div`
   letter-spacing: 0.2em;
   color: ${(props) => props.theme.colors.black};
   user-select: none;
+  @media screen and (max-width: 480px) {
+    display: none;
 `
 
 export default function _LogoHeader() {

--- a/src/components/PlayerOfTheWeek.js
+++ b/src/components/PlayerOfTheWeek.js
@@ -125,10 +125,6 @@ export default function PlayerOfTheWeek({ user, avatar }) {
           <StatHeading>weekly wins</StatHeading>
           <Stat>{user?.weeklyWins ?? '-'}</Stat>
         </StatColumn>
-        <StatColumn>
-          <StatHeading>$prem earned</StatHeading>
-          <Stat>{user?.premEarned ?? '-'}</Stat>
-        </StatColumn>
       </StatsRow>
       <LeaderboardTitle>Share this page</LeaderboardTitle>
       <ShareRow>

--- a/src/components/ProfileHome.js
+++ b/src/components/ProfileHome.js
@@ -136,10 +136,6 @@ export default function Home({ friends }) {
           <Numbers>3</Numbers>
         </GreyTextColumn>
         <GreyTextColumn>
-          <GrayText>$prem earned</GrayText>
-          <Numbers>2310994</Numbers>
-        </GreyTextColumn>
-        <GreyTextColumn>
           <GrayText>usd earned</GrayText>
           <Numbers>$4,301</Numbers>
         </GreyTextColumn>

--- a/src/components/ProfileTop.js
+++ b/src/components/ProfileTop.js
@@ -4,7 +4,6 @@ import { Column, Container, Row } from 'components/common'
 import Image from 'next/image'
 import { useState } from 'react'
 import Friends from 'components/Friends'
-import Teams from 'components/Teams'
 import Home from 'components/ProfileHome'
 import History from 'components/History'
 import Link from 'next/link'
@@ -142,7 +141,6 @@ export default function ProfileTop() {
             {avatar && <Avatar src={avatar} />}
             <ProfileInfo>
               <Name>{user?.username}</Name>
-              <Team>{user?.team}</Team>
               <ProfileStats>
                 <GreyTextColumn>
                   <GreyText>rank</GreyText>
@@ -188,12 +186,6 @@ export default function ProfileTop() {
             event history
           </Button>
           <Button
-            style={{ borderBottom: `${selected == 'Teams' ? 1 : 0}px solid` }}
-            onClick={() => setSelected('Teams')}
-          >
-            teams
-          </Button>
-          <Button
             style={{ borderBottom: `${selected == 'Friends' ? 1 : 0}px solid` }}
             onClick={() => setSelected('Friends')}
           >
@@ -206,7 +198,6 @@ export default function ProfileTop() {
           </Link>
         </ButtonWrapper>
       </Wrapper>
-      {selected == 'Teams' && <Teams />}
       {selected == 'Friends' && <Friends friends={friends} />}
       {selected == 'Home' && <Home friends={friends} />}
     </Column>

--- a/src/components/SocialsSection.js
+++ b/src/components/SocialsSection.js
@@ -18,9 +18,6 @@ const Row = styled(_Row)`
     flex-direction: column;
     height: 200px;
   }
-  @media screen and (max-width: 450px) {
-    width: 500px;
-  }
 `
 
 const Column = styled(_Column)`
@@ -31,19 +28,26 @@ const Text1 = styled.div`
   font-family: Inter;
   font-style: normal;
   font-weight: normal;
-  font-size: 24px;
+  font-size: 1.5em;
   line-height: 150%;
   text-align: center;
   color: ${(props) => props.theme.colors.black};
+  @media screen and (max-width: 1065px) {
+    font-size: 1.2em
+  }
 `
 
 const Text2 = styled.div`
   font-family: Inter;
   font-style: italic;
   font-weight: bold;
-  font-size: 45px;
+  font-size: 3em;
   line-height: 100%;
   color: ${(props) => props.theme.colors.black};
+  @media screen and (max-width: 1065px) {
+    font-size: 35px;
+    text-align: center;
+  }
 `
 
 const SocialsRow = styled(_Row)`

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -31,6 +31,8 @@ const GlobalStyle = createGlobalStyle`
   html, body {
     margin: 0;
     padding: 0;
+    max-width: 100%;
+    overflow-x: hidden;
     box-sizing: border-box;
     font-family: Inter;
     font-style: normal;


### PR DESCRIPTION
Fixed mobile scaling on header and homepage:
-remove page horizontal scrolling
-change font size on smaller screens
-hide 'premiere' on smaller screens so other components fit
-fix margin/spacing on header
-increase size of dropdown icon
-centre button/images/text on smaller screens
-socials section scales on mobile

(Will submit separate PR to improve mobile scaling on other pages, want to make sure this merges ok and breakpoints work - have tested in responsive design mode only).

Before:
![Screenshot 2022-07-14 at 12 02 46](https://user-images.githubusercontent.com/49661708/178970921-897c4c14-7292-4e73-bac0-e370cfbbef05.png)

After:
![Screenshot 2022-07-14 at 09 07 29](https://user-images.githubusercontent.com/49661708/178970958-b3eda72d-9f48-45c3-811d-090769577ad4.png)


 