### PR TITLE
User profile styling fixes and gradient-text bug fix

### DIFF
--- a/src/components/Buttons.js
+++ b/src/components/Buttons.js
@@ -148,9 +148,21 @@ export function ShareButton(){
 }
 
 export function ArrowButton({ text }) {
+
+  const Text = styled(GradientText)`
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 150%;
+  letter-spacing: 0.1em;
+  color: ${(props) => props.theme.colors.black};
+  user-select: none;
+  `
+  
   return (
     <ArrowButtonContainer>
-      {text}
+ <Text>{text}</Text>
       <div style={{ marginBottom: 10, marginLeft: 15 }}>
         <Image
           src={'/arrow-right-gradient.svg'}

--- a/src/components/CurrentUserProfileTop.js
+++ b/src/components/CurrentUserProfileTop.js
@@ -58,7 +58,7 @@ const ProfileStats = styled(Row)``
 const ProfileButtons = styled(Row)`
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: space-around;
   height: 220px;
 `
 
@@ -73,6 +73,14 @@ const GreyText = styled.div`
   color: ${(props) => props.theme.colors.gray};
   letter-spacing: 0.1em;
   text-transform: uppercase;
+`
+
+const Joined = styled.div`
+  font-size: 20px;
+  line-height: 42px;
+  font-weight: 500;
+  margin-bottom:50px;
+  color: ${(props) => props.theme.colors.gray};
 `
 
 const ArrowColumn = styled(Column)`
@@ -101,7 +109,9 @@ const Button = styled.div`
   font-weight: 500;
   line-height: 40px;
   letter-spacing: 0.1em;
-  border-bottom: 0px solid;
+  border-top: 0px;
+  border-left: 0px;
+  border-right: 0px;
   border-image-source: linear-gradient(
     266.89deg,
     #982649 -18.13%,
@@ -350,6 +360,7 @@ export default function ProfileTop() {
             )}
             <ProfileInfo>
               <Name>{user?.username || user?.email}</Name>
+              <Joined>UK Member since 16 August 2001</Joined>
               <ProfileStats>
                 <GreyTextColumn>
                   <GreyText>rank</GreyText>
@@ -419,25 +430,25 @@ export default function ProfileTop() {
         </EditAvatarColumn>
         <ButtonWrapper>
           <ButtonHome
-            style={{ borderBottom: `${selected == 'Home' ? 1 : 0}px solid` }}
+            style={{ borderBottom: `${selected == 'Home' ? 4 : 0}px solid` }}
             onClick={() => setSelected('Home')}
           >
             home
           </ButtonHome>
           <Button
-            style={{ borderBottom: `${selected == 'History' ? 1 : 0}px solid` }}
+            style={{ borderBottom: `${selected == 'History' ? 4 : 0}px solid` }}
             onClick={() => setSelected('History')}
           >
             event history
           </Button>
           <Button
-            style={{ borderBottom: `${selected == 'Teams' ? 1 : 0}px solid` }}
+            style={{ borderBottom: `${selected == 'Teams' ? 4 : 0}px solid` }}
             onClick={() => setSelected('Teams')}
           >
             Teams
           </Button>
           <Button
-            style={{ borderBottom: `${selected == 'Friends' ? 1 : 0}px solid` }}
+            style={{ borderBottom: `${selected == 'Friends' ? 4 : 0}px solid` }}
             onClick={() => setSelected('Friends')}
           >
             friends


### PR DESCRIPTION
Couple of bug and styling fixes:

-gradient-text buttons were not showing in certain browsers. 
-added User member since info.
-fixed spacing between share and edit button
-user profile selected tab bottom border only as per figma design.

Before:
![Screenshot 2022-07-25 at 21 30 04](https://user-images.githubusercontent.com/49661708/180871857-138f5acc-0a52-44c3-b7d9-cd38531e4b9d.png)

After:
![Screenshot 2022-07-25 at 21 30 22](https://user-images.githubusercontent.com/49661708/180871913-43c688aa-a939-4284-8b82-2c8d365081b6.png)


Before:
![Screenshot 2022-07-25 at 21 46 24](https://user-images.githubusercontent.com/49661708/180871938-e98d1c4a-31f3-4894-9f5b-4aa5cd8a0ca6.png)

After:
![Screenshot 2022-07-25 at 21 46 39](https://user-images.githubusercontent.com/49661708/180871961-80bc9356-f179-41be-a0a5-c27091c33394.png)

