### PR TITLE
PREM-34 Tournaments page functionality

### DIFF
--- a/src/calls/index.js
+++ b/src/calls/index.js
@@ -1,3 +1,6 @@
+import { db } from '../firebase/firebase'
+import { doc, getDocs, collection } from "firebase/firestore"; 
+
 export async function getPlayerOfTheWeek() {
   const player = {
     name: 'devonhenry_',
@@ -19,35 +22,14 @@ export async function getGames() {
   }
 }
 
-export async function getTournaments() {
-  try {
-    let tournaments = []
-    const months = [
-      'January',
-      'February',
-      'March',
-      'April',
-      'May',
-      'June',
-      'July',
-      'August',
-      'September',
-      'October',
-      'November',
-      'December'
-    ]
-    function makeTimeRight(tournament) {
-      const unix = tournament.time
-      let date = new Date(unix * 1000)
-      let year = date.getFullYear()
-      let day = date.getDate()
-      let month = months[date.getMonth()]
-      let hours = date.getHours()
-      let minutes = date.getMinutes()
-      tournament.time = `${hours}:${minutes}`
-      tournament.date = `${day} ${month} ${year}`
-      return tournament
-    }
+export const getTournaments = async () => {
+  try{
+    const querySnapshot = await getDocs(collection(db, 'tournaments'))
+    const tournaments = querySnapshot.docs.map(doc => {
+      const data = doc.data()
+      const id = doc.id
+      return {id, ...data}
+    })
     return tournaments
   } catch (error) {
     console.log(error)

--- a/src/components/AllTournaments.js
+++ b/src/components/AllTournaments.js
@@ -6,12 +6,6 @@ import { Grid, Cell } from 'styled-css-grid'
 import { getTournaments } from 'calls'
 import styled from 'styled-components'
 import Menu from 'components/Filter'
-import {
-  InstantSearch,
-  connectHits,
-  connectMenu
-} from 'react-instantsearch-dom'
-import { searchClient } from 'algolia/index'
 
 const SubheadingRow = styled(Row)`
   margin-bottom: 80px;
@@ -20,14 +14,11 @@ const SubheadingRow = styled(Row)`
   }
 `
 
-const CustomMenuSelect = connectMenu(Menu)
-
-const Hits = connectHits(({ hits }) => {
+const Hits = (({ hits }) => {
   const [width, setWidth] = useState(null)
 
   useEffect(function () {
     setWidth(window.innerWidth)
-    console.log(window.innerWidth)
   }, [])
 
   const items = hits.map((hit, idx) => (
@@ -46,27 +37,48 @@ const Hits = connectHits(({ hits }) => {
 })
 
 export default function AllTournaments({ tournaments }) {
-  // TO ADD TOURNAMNETS TO ALGOLIA:
-  // const index = searchClient.initIndex('tournaments')
-  // index
-  //   .saveObjects(tournaments, {
-  //     autoGenerateObjectIDIfNotExist: true
-  //   })
-  //   .then(objectIDs)
+ 
+  const [filterOption, setFilterOption]=useState(null)
+  const [filteredTournaments, setFilteredTournaments] =useState(tournaments)
+
+  const handleTournamentMenu = (option)=>{
+    setFilterOption(option)
+  }
+
+  const menuItems = tournaments.map((tournament, index)=>{
+    return{
+      label: tournament.game,
+      value: tournament.game
+    }
+  })
+
+  useEffect(()=>{
+    if(filterOption !== null){
+      setFilteredTournaments(tournaments.filter((tournament)=> {return tournament.game == filterOption}))
+    } 
+    if(filterOption == 'all'){
+      setFilteredTournaments(tournaments)
+    }   
+  },[filterOption])
 
   return (
-    <div>
-      <InstantSearch searchClient={searchClient} indexName="tournaments">
+    <>
         <Container>
           <SubheadingRow style={{ justifyContent: 'space-between' }}>
             <Subheading>TOURNAMENTS</Subheading>
-            <CustomMenuSelect attribute="game" option={'game'} />
+            <Menu 
+              attribute={'game'} 
+              option={'game'} 
+              items={menuItems} 
+              handleTournamentMenu={handleTournamentMenu}
+            />
           </SubheadingRow>
         </Container>
+        {filteredTournaments.length>0 && (
         <Container style={{ marginBottom: 220 }}>
-          <Hits />
+          <Hits hits={filteredTournaments}/>
         </Container>
-      </InstantSearch>
-    </div>
+        )}
+    </>
   )
 }

--- a/src/components/CreateTournament.tsx
+++ b/src/components/CreateTournament.tsx
@@ -190,14 +190,23 @@ export default function CreateTournament() {
   const [selectedRegion, setSelectedRegion] = useState('international')
   const [selectedPlatform, setSelectedPlatform] = useState('')
   const [selectedTime, setSelectedTime] = useState('')
+  const [selectedDate, setSelectedDate] = useState('')
   const [selectedGame, setSelectedGame] = useState('')
+  const [name,setName]= useState('')
+  const [description, setDescription] = useState('')
+  const [prize, setPrize] = useState('')
 
   const handleRegionSelect = (newValue: Region) => {
     setSelectedRegion(newValue.value)
   }
 
-  const handleTimeSelect = (newValue: Region) => {
+  const handleTimeSelect = (newValue: Time) => {
     setSelectedTime(newValue.value)
+  }
+
+  const handleDateSelect = (newValue) => {
+    const date: Date = new Date(newValue)
+    setSelectedDate(date.toLocaleDateString())
   }
 
   const handlePlatformSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -208,7 +217,6 @@ export default function CreateTournament() {
   const handleGameSelect = (e: React.MouseEvent<HTMLInputElement>) => {
     const value = (e.target as HTMLInputElement).value
     setSelectedGame(value)
-    console.log(selectedGame)
   }
 
   const cancel = () => {
@@ -241,12 +249,16 @@ export default function CreateTournament() {
   const onSubmit = async (data: Tournament) => {
     const tournamentData = {
       ...data,
-      creator: user,
-      users: '',
       region: selectedRegion,
-      time: getDate(data.time),
+      name: name,
+      description: description,
+      time: selectedTime,
+      date: selectedDate,
+      game: selectedGame,
+      prize: prize,
+      users: '',
+      creator: user.uid,
       platform: selectedPlatform,
-      game: selectedGame
     }
     console.log('tournament', tournamentData)
   }
@@ -320,11 +332,19 @@ export default function CreateTournament() {
         <InputColumn>
           <TournamentNameEntry>
             <Caption>name</Caption>
-            <Input required={true} {...register('name')} type={'text'} />
+            <Input 
+              required={true} {...register('name')} 
+              type={'text'} value={name} 
+              onChange={e => setName(e.target.value)}
+            />
           </TournamentNameEntry>
           <DescriptionEntry>
             <Caption>description</Caption>
-            <DescriptionInput required={true} {...register('description')} />
+            <DescriptionInput 
+              required={true} {...register('description')} 
+              value={description} 
+              onChange={e => setDescription(e.target.value)}
+            />
           </DescriptionEntry>
         </InputColumn>
         <InputRow>
@@ -343,13 +363,17 @@ export default function CreateTournament() {
               <Select
                 options={getTimes()}
                 styles={regionStyles}
-                onChange={handleTimeSelect}
+                onChange={e=>handleTimeSelect(e)}
                 placeholder={'00:00'}
               />
             </TournamentEntry>
             <DateEntry>
               <Caption>date</Caption>
-              <DateInput required={true} {...register('time')} type={'date'} />
+              <DateInput 
+                required={true} {...register('time')} 
+                type={'date'} 
+                onChange={e => handleDateSelect(e.target.valueAsNumber)}
+              />
             </DateEntry>
           </InputColumn>
           <InputColumn>
@@ -372,6 +396,7 @@ export default function CreateTournament() {
                 type={'number'}
                 min={0.0001}
                 step={0.0001}
+                onChange={(e)=>setPrize(e.target.value)}
                 max={1}
                 placeholder={'0.0001'}
               />

--- a/src/components/CreateTournament.tsx
+++ b/src/components/CreateTournament.tsx
@@ -10,6 +10,9 @@ import Checkbox, { CheckboxProps } from 'components/Checkbox'
 import { LoginButton } from './Buttons'
 import moment from 'moment'
 import SelectGameModal from 'components/SelectGameModal'
+import { db } from '../firebase/firebase'
+import { addDoc, collection } from "firebase/firestore"; 
+import { useRouter } from 'next/router'
 
 const FormContainer = styled.form`
   margin: auto;
@@ -180,11 +183,15 @@ interface Games {
 }
 
 export default function CreateTournament() {
+
+  const router = useRouter()
+
   const {
     register,
     handleSubmit,
     formState: { errors }
   } = useForm()
+
   const { user } = useContext(AuthenticationContext)
   const [errorMessage, setErrorMessage] = useState('')
   const [selectedRegion, setSelectedRegion] = useState('international')
@@ -261,6 +268,17 @@ export default function CreateTournament() {
       platform: selectedPlatform,
     }
     console.log('tournament', tournamentData)
+    
+    try {
+      const docRef = await addDoc(collection(db, "tournaments"),tournamentData);
+      console.log('tournament added with ID: ' + docRef.id)
+      if(docRef.id){
+        router.push('/tournaments')
+      }
+    } catch(e){
+      setErrorMessage(e.message)
+      console.error('Error adding document: ', e)
+    }
   }
 
   const regionOptions: Region[] = [

--- a/src/components/Filter.js
+++ b/src/components/Filter.js
@@ -64,14 +64,19 @@ const DropdownOption = styled.button`
   flex-direction: row;
 `
 
-export default function Menu({ items, currentRefinement, refine, option }) {
+export default function Menu({ items, currentRefinement, refine, option, handleTournamentMenu }) {
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [selectedLeaderboard, setSelectedLeaderboard] = useState()
 
   const handleOptionSelect = (e) => {
     if (option == 'leaderboard') setSelectedLeaderboard(e.currentTarget.name)
+    if (option == 'game') {
+      if(e == 'all'){
+        handleTournamentMenu('all')
+      }
+      else handleTournamentMenu(e.target.textContent)
+    }
     setDropdownOpen(false)
-    refine(e.currentTarget.value)
   }
 
   const switchText = (option) => {
@@ -104,7 +109,7 @@ export default function Menu({ items, currentRefinement, refine, option }) {
       {dropdownOpen && (
         <Dropdown>
           {option != 'leaderboard' && (
-            <DropdownOption onClick={handleOptionSelect} value={null}>
+            <DropdownOption onClick={()=> handleOptionSelect('all')} value={null}>
               <Option>ALL {option}S</Option>
             </DropdownOption>
           )}

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -1,4 +1,5 @@
 import { initializeApp } from 'firebase/app'
+import { getFirestore } from "firebase/firestore";
 import 'firebase/auth'
 
 const app = initializeApp({
@@ -11,4 +12,6 @@ const app = initializeApp({
   measurementId: 'G-F8REW9W40C'
 })
 
-export { app }
+const db = getFirestore(app)
+
+export { app, db }

--- a/src/pages/tournaments.js
+++ b/src/pages/tournaments.js
@@ -1,3 +1,4 @@
+import React, {useState, useEffect} from 'react'
 import Header from 'components/Header'
 import Footer from 'components/Footer'
 import { Row, Column } from 'components/common'
@@ -6,17 +7,9 @@ import { getTournaments, getGames } from 'calls'
 import AllTournaments from 'components/AllTournaments'
 
 export default function Tournaments({ tournaments, games }) {
-  // TO ADD TOURNAMNETS TO ALGOLIA:
-  // const index = searchClient.initIndex('tournaments')
-  // index
-  //   .saveObjects(tournaments, {
-  //     autoGenerateObjectIDIfNotExist: true
-  //   })
-  //   .then(objectIDs)
 
   return (
     <Column>
-      <Header />
       <Header games={games} tournaments={tournaments} />
       {tournaments?.length && (
         <div style={{ marginBottom: 150 }}>


### PR DESCRIPTION
Added most of the Tournaments page functionality with Firebase including:

- Fix /create-tournament page forms.
- Handle upload of new tournament to firebase
- getTournaments call retrieves tournaments from firebase and displays on relevant pages
- game filter button on Tournaments page works correctly.

Active nav / header tournaments bar:
![Screenshot 2022-08-10 at 12 14 59](https://user-images.githubusercontent.com/49661708/184347353-f284e07c-7f21-43c2-ae1e-7c1d5536a3f5.png)


Firebase collection:
![Screenshot 2022-08-10 at 12 15 40](https://user-images.githubusercontent.com/49661708/184347346-3ec6f6f4-5efb-47f8-9452-1fa2fbdf9c2c.png)


Filter displays only the games included in the tournaments collection:
![Screenshot 2022-08-12 at 12 44 31](https://user-images.githubusercontent.com/49661708/184347480-6d9c3227-0489-46ca-ab20-53ee8be5066f.png)


